### PR TITLE
Juno BYOK onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A command-line tool for managing cloud integrations with Uptycs, supporting AWS,
   - Log integrations
   - Scanner configurations
   - Target configurations
-- JUNO BYOK (Bring Your Own Key) credential management
+- Juno BYOK (Bring Your Own Key) credential management
 
 ## Prerequisites
 
@@ -56,9 +56,9 @@ The basic command structure for cloud operations is:
 python onboard.py --config <config_file> --cloud <provider> --action <action> --type <type> [additional options]
 ```
 
-### JUNO BYOK Operations
+### Juno BYOK Operations
 
-For JUNO BYOK credential management:
+For Juno BYOK credential management:
 
 ```bash
 python onboard.py --config <config_file> --juno --action <action> --type byok [additional options]
@@ -74,11 +74,11 @@ python onboard.py --config <config_file> --juno --action <action> --type byok [a
 - `--tenant-id`: Tenant/Account ID (for cloud operations)
 - `--integration-prefix`: Integration prefix (for cloud operations)
 
-#### For JUNO BYOK Operations
+#### For Juno BYOK Operations
 - `--config`: Path to Uptycs API configuration file
-- `--juno`: Flag to indicate JUNO operations
+- `--juno`: Flag to indicate Juno operations
 - `--action`: Action to perform (create, update, delete, get)
-- `--type`: Must be `byok` (only valid type for JUNO operations)
+- `--type`: Must be `byok` (only valid type for Juno operations)
 - `--key`: AWS access key ID (required for create/update)
 - `--secret`: AWS secret access key (required for create/update)
 - `--region`: AWS region (optional, default: us-east-1)
@@ -140,7 +140,7 @@ python onboard.py --config config.json \
     --tenant-id "subscription-id"
 ```
 
-4. Create JUNO BYOK credentials:
+4. Create Juno BYOK credentials:
 ```bash
 python onboard.py --config config.json \
     --juno \
@@ -151,7 +151,7 @@ python onboard.py --config config.json \
     --region "us-east-1"
 ```
 
-5. Get JUNO BYOK credentials:
+5. Get Juno BYOK credentials:
 ```bash
 python onboard.py --config config.json \
     --juno \
@@ -159,7 +159,7 @@ python onboard.py --config config.json \
     --type byok
 ```
 
-6. Update JUNO BYOK credentials:
+6. Update Juno BYOK credentials:
 ```bash
 python onboard.py --config config.json \
     --juno \
@@ -170,7 +170,7 @@ python onboard.py --config config.json \
     --region "us-west-2"
 ```
 
-7. Delete JUNO BYOK credentials:
+7. Delete Juno BYOK credentials:
 ```bash
 python onboard.py --config config.json \
     --juno \
@@ -189,7 +189,7 @@ The tool includes comprehensive error handling and will provide clear error mess
 
 ## Important Notes
 
-### JUNO BYOK
+### Juno BYOK
 - The `--type byok` option is **only** supported with the `--juno` flag
 - BYOK operations require AWS credentials (access key ID and secret access key)
 - The default AWS region is `us-east-1` if not specified

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A command-line tool for managing cloud integrations with Uptycs, supporting AWS,
   - Log integrations
   - Scanner configurations
   - Target configurations
+- JUNO BYOK (Bring Your Own Key) credential management
 
 ## Prerequisites
 
@@ -47,20 +48,40 @@ Create a JSON configuration file with your Uptycs API credentials:
 
 ## Usage
 
-The basic command structure is:
+### Cloud Integration Operations
+
+The basic command structure for cloud operations is:
 
 ```bash
 python onboard.py --config <config_file> --cloud <provider> --action <action> --type <type> [additional options]
 ```
 
+### JUNO BYOK Operations
+
+For JUNO BYOK credential management:
+
+```bash
+python onboard.py --config <config_file> --juno --action <action> --type byok [additional options]
+```
+
 ### Required Arguments
 
+#### For Cloud Operations
 - `--config`: Path to Uptycs API configuration file
-- `--cloud`: Cloud provider (aws, gcp, azure)
-- `--action`: Action to perform (create, update, delete, purge)
+- `--cloud`: Cloud provider (aws, gcp, azure, ibm)
+- `--action`: Action to perform (create, update, delete, purge, get)
 - `--type`: Integration type (account, organization, logs, scanner, target, logs-pubsub)
-- `--tenant-id`: Tenant/Account ID
-- `--integration-prefix`: Integration prefix
+- `--tenant-id`: Tenant/Account ID (for cloud operations)
+- `--integration-prefix`: Integration prefix (for cloud operations)
+
+#### For JUNO BYOK Operations
+- `--config`: Path to Uptycs API configuration file
+- `--juno`: Flag to indicate JUNO operations
+- `--action`: Action to perform (create, update, delete, get)
+- `--type`: Must be `byok` (only valid type for JUNO operations)
+- `--key`: AWS access key ID (required for create/update)
+- `--secret`: AWS secret access key (required for create/update)
+- `--region`: AWS region (optional, default: us-east-1)
 
 ### Cloud-Specific Arguments
 
@@ -119,6 +140,44 @@ python onboard.py --config config.json \
     --tenant-id "subscription-id"
 ```
 
+4. Create JUNO BYOK credentials:
+```bash
+python onboard.py --config config.json \
+    --juno \
+    --action create \
+    --type byok \
+    --key "AKIAIOSFODNN7EXAMPLE" \
+    --secret "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
+    --region "us-east-1"
+```
+
+5. Get JUNO BYOK credentials:
+```bash
+python onboard.py --config config.json \
+    --juno \
+    --action get \
+    --type byok
+```
+
+6. Update JUNO BYOK credentials:
+```bash
+python onboard.py --config config.json \
+    --juno \
+    --action update \
+    --type byok \
+    --key "AKIAIOSFODNN7EXAMPLE" \
+    --secret "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
+    --region "us-west-2"
+```
+
+7. Delete JUNO BYOK credentials:
+```bash
+python onboard.py --config config.json \
+    --juno \
+    --action delete \
+    --type byok
+```
+
 ## Error Handling
 
 The tool includes comprehensive error handling and will provide clear error messages if:
@@ -126,6 +185,16 @@ The tool includes comprehensive error handling and will provide clear error mess
 - API configuration is invalid
 - Cloud provider credentials are incorrect
 - API requests fail
+- Invalid flag combinations (e.g., using `--type byok` without `--juno`)
+
+## Important Notes
+
+### JUNO BYOK
+- The `--type byok` option is **only** supported with the `--juno` flag
+- BYOK operations require AWS credentials (access key ID and secret access key)
+- The default AWS region is `us-east-1` if not specified
+- Use the `get` action to retrieve existing BYOK credentials
+- `create` and `update` actions require both `--key` and `--secret` parameters
 
 ## Support
 

--- a/onboard.py
+++ b/onboard.py
@@ -197,8 +197,8 @@ def validate_args(args, required_fields):
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Uptycs Cloud Onboarding Script v1.0.0")
     parser.add_argument("--config", required=True, help="Path to Uptycs API configuration file")
-    parser.add_argument("--cloud", choices=["aws", "gcp", "azure", "ibm"], help="Cloud provider")
-    parser.add_argument("--juno", action="store_true", help="JUNO operations (use instead of --cloud)")
+    parser.add_argument("--cloud", choices=["aws", "gcp", "azure", "ibm"], help="Cloud operations: provide cloud provider")
+    parser.add_argument("--juno", action="store_true", help="JUNO operations")
     parser.add_argument("--action", choices=["create", "update", "delete", "purge", "get"], required=True, help="Action to perform")
     parser.add_argument("--type", choices=["account", "organization", "logs", "scanner", "target", "logs-pubsub", "byok"], required=True, help="type type")
     

--- a/onboard.py
+++ b/onboard.py
@@ -68,8 +68,10 @@ class UptycsAPI:
 
     def _build_url(self, endpoint: str) -> str:
         try:
-            prefix = "v2" if "agentless" in endpoint else ""
+            prefix = "v2" if ("agentless" in endpoint or endpoint.startswith("v2/")) else ""
             if prefix:
+                # Remove v2/ prefix from endpoint if it exists since we're adding it in the URL
+                endpoint = endpoint.replace("v2/", "", 1) if endpoint.startswith("v2/") else endpoint
                 return f"{self.base_url}/public/api/{prefix}/customers/{self.customer_id}/{endpoint}"
             return f"{self.base_url}/public/api/customers/{self.customer_id}/{endpoint}"
         except Exception as e:
@@ -81,7 +83,6 @@ class UptycsAPI:
             url = self._build_url(endpoint)
             self._update_jwt_token()
             response = self.session.request(method, url, **kwargs)
-            print(response.text)
             response.raise_for_status()
             if response.text.strip():
                 try:
@@ -132,6 +133,23 @@ class UptycsAPI:
         except Exception as e:
             print(f"Error managing type: {e}") 
 
+    def manage_juno_byok(self, action: str, key: Optional[str] = None, secret: Optional[str] = None, region: str = "us-east-1") -> Any:
+        try:
+            endpoint = "v2/juno/byok_credentials"
+            if action == "get":
+                return self._make_request('GET', endpoint)
+            elif action in ["create", "update"]:
+                payload = {"key": key, "secret": secret, "region": region}
+                return self._make_request('POST', endpoint, json=payload)
+            elif action == "delete":
+                return self._make_request('DELETE', endpoint)
+            else:
+                print(f"Error: Unsupported action '{action}' for JUNO BYOK")
+                sys.exit(1)
+        except Exception as e:
+            print(f"Error managing JUNO BYOK: {e}")
+            sys.exit(1)
+
     def delete_type(self, tenant_id: str, type: str, connector_type: Optional[str] = None, name: Optional[str] = None) -> Optional[Dict[str, Any]]:
         try:
             if type == "account":
@@ -179,9 +197,10 @@ def validate_args(args, required_fields):
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Uptycs Cloud Onboarding Script v1.0.0")
     parser.add_argument("--config", required=True, help="Path to Uptycs API configuration file")
-    parser.add_argument("--cloud", choices=["aws", "gcp", "azure", "ibm"], required=True, help="Cloud provider")
-    parser.add_argument("--action", choices=["create", "update", "delete", "purge"], required=True, help="Action to perform")
-    parser.add_argument("--type", choices=["account", "organization", "logs", "scanner", "target", "logs-pubsub"], required=True, help="type type")
+    parser.add_argument("--cloud", choices=["aws", "gcp", "azure", "ibm"], help="Cloud provider")
+    parser.add_argument("--juno", action="store_true", help="JUNO operations (use instead of --cloud)")
+    parser.add_argument("--action", choices=["create", "update", "delete", "purge", "get"], required=True, help="Action to perform")
+    parser.add_argument("--type", choices=["account", "organization", "logs", "scanner", "target", "logs-pubsub", "byok"], required=True, help="type type")
     
     # CSPM-specific arguments
     parser.add_argument("--tenant-id", help="Tenant/Account ID")
@@ -219,6 +238,11 @@ def parse_arguments():
     
     # Target-specific arguments
     parser.add_argument("--uptycs-scanner", choices=["true", "false"], default="false", help="Enable Uptycs Managed Scanner (AWS scanner only)")
+
+    # JUNO BYOK arguments
+    parser.add_argument("--key", help="AWS access key ID (JUNO BYOK only)")
+    parser.add_argument("--secret", help="AWS secret access key (JUNO BYOK only)")
+    parser.add_argument("--region", default="us-east-1", help="AWS region (JUNO BYOK only, default: us-east-1)")
 
     return parser.parse_args()
 
@@ -365,6 +389,35 @@ def main():
     except ValueError as e:
         print(f"Error: {e}")
         sys.exit(1)
+
+    # Validate that --type byok requires --juno
+    if args.type == "byok" and not args.juno:
+        print("Error: --type byok is only supported with --juno")
+        sys.exit(1)
+
+    # Handle JUNO operations
+    if args.juno:
+        if args.type != "byok":
+            print("Error: --juno requires --type byok")
+            sys.exit(1)
+
+        # Validate required fields for BYOK operations
+        if args.action in ["create", "update"]:
+            if not args.key or not args.secret:
+                print("Error: --key and --secret are required for BYOK create/update actions")
+                sys.exit(1)
+
+        # Execute BYOK operation
+        result = api.manage_juno_byok(args.action, args.key, args.secret, args.region)
+        if result:
+            print(json.dumps(result, indent=2))
+        return
+
+    # Handle cloud operations
+    if not args.cloud:
+        print("Error: --cloud is required for cloud operations")
+        sys.exit(1)
+
     required_fields = ["tenant_id"]
     if args.type == "account":
         if args.action == "create":

--- a/onboard.py
+++ b/onboard.py
@@ -144,10 +144,10 @@ class UptycsAPI:
             elif action == "delete":
                 return self._make_request('DELETE', endpoint)
             else:
-                print(f"Error: Unsupported action '{action}' for JUNO BYOK")
+                print(f"Error: Unsupported action '{action}' for Juno BYOK")
                 sys.exit(1)
         except Exception as e:
-            print(f"Error managing JUNO BYOK: {e}")
+            print(f"Error managing Juno BYOK: {e}")
             sys.exit(1)
 
     def delete_type(self, tenant_id: str, type: str, connector_type: Optional[str] = None, name: Optional[str] = None) -> Optional[Dict[str, Any]]:
@@ -198,7 +198,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description="Uptycs Cloud Onboarding Script v1.0.0")
     parser.add_argument("--config", required=True, help="Path to Uptycs API configuration file")
     parser.add_argument("--cloud", choices=["aws", "gcp", "azure", "ibm"], help="Cloud operations: provide cloud provider")
-    parser.add_argument("--juno", action="store_true", help="JUNO operations")
+    parser.add_argument("--juno", action="store_true", help="Juno operations")
     parser.add_argument("--action", choices=["create", "update", "delete", "purge", "get"], required=True, help="Action to perform")
     parser.add_argument("--type", choices=["account", "organization", "logs", "scanner", "target", "logs-pubsub", "byok"], required=True, help="type type")
     
@@ -239,10 +239,10 @@ def parse_arguments():
     # Target-specific arguments
     parser.add_argument("--uptycs-scanner", choices=["true", "false"], default="false", help="Enable Uptycs Managed Scanner (AWS scanner only)")
 
-    # JUNO BYOK arguments
-    parser.add_argument("--key", help="AWS access key ID (JUNO BYOK only)")
-    parser.add_argument("--secret", help="AWS secret access key (JUNO BYOK only)")
-    parser.add_argument("--region", default="us-east-1", help="AWS region (JUNO BYOK only, default: us-east-1)")
+    # Juno BYOK arguments
+    parser.add_argument("--key", help="AWS access key ID (Juno BYOK only)")
+    parser.add_argument("--secret", help="AWS secret access key (Juno BYOK only)")
+    parser.add_argument("--region", default="us-east-1", help="AWS region (Juno BYOK only, default: us-east-1)")
 
     return parser.parse_args()
 
@@ -395,7 +395,7 @@ def main():
         print("Error: --type byok is only supported with --juno")
         sys.exit(1)
 
-    # Handle JUNO operations
+    # Handle Juno operations
     if args.juno:
         if args.type != "byok":
             print("Error: --juno requires --type byok")


### PR DESCRIPTION
Juno Support into Onboarding
- For now in Juno Operations we support onboarding of BYOK 

**To configure BYOK**
```
gkondisetty@gkondisetty-mac onboarding % python3 onboard.py --config ~/Downloads/marvel_apikey.json --juno --action create --type byok --key AKIAIOSFODNN7EXAMPLE --secret wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
{
  "accessConfig": {
    "key": "****************MPLE",
    "region": "us-east-1",
    "secret": "************************************EKEY"
  },
  "accessType": "bedrock"
}
gkondisetty@gkondisetty-mac onboarding %
```

**To Confirm BYOK** 
```
gkondisetty@gkondisetty-mac onboarding % python3 onboard.py --config ~/Downloads/marvel_apikey.json --juno --action get --type byok
{
  "accessType": "bedrock",
  "configured": true
}
gkondisetty@gkondisetty-mac onboarding % 
```

**To Delete BYOK Creds**
```
gkondisetty@gkondisetty-mac onboarding % python3 onboard.py --config ~/Downloads/marvel_apikey.json --juno --action delete --type byok
{
  "status": "success",
  "code": 204
}
gkondisetty@gkondisetty-mac onboarding %
```